### PR TITLE
Add (partial) support for linguistic

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.luau linguist-language=Lua linguist-detectable

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.luau linguist-language=Lua linguist-detectable
+*.luau linguist-language=Lua


### PR DESCRIPTION
```gitattributes
*.luau linguist-language=Lua
```
`.gitattributes` allows for `.luau` files to be identified as Lua files which allows for syntax highlighting on GitHub. I could technically turn all `.luau` files into `.lua` ones but I don't feel that's the right solution.

Sadly, statistics are not yet supportable for Luau.
