### PR TITLE
Implement None and Void

### DIFF
--- a/src/Assembler.lua
+++ b/src/Assembler.lua
@@ -1,12 +1,18 @@
 --!strict
 
+-->> Modules
+
 local t = require(script.Parent.Parent.t)
+
 local Types = require(script.Parent.Types)
+local None = require(script.Parent.None)
+
+-->> Assembler
 
 local Assembler = { _isAssembler = true }
 
 function Assembler.__call<T>(self: _Assembler, data: T): Types.Component<T>
-	return {data = data, name = self._name}
+	return {data = if data == nil then None else data, name = self._name}
 end
 
 function Assembler.__tostring(self: _Assembler): string

--- a/src/None.lua
+++ b/src/None.lua
@@ -1,0 +1,1 @@
+return { None = true }

--- a/src/Void.lua
+++ b/src/Void.lua
@@ -1,0 +1,1 @@
+return { Void = true }

--- a/src/World.lua
+++ b/src/World.lua
@@ -1,7 +1,13 @@
 --!strict
 
+-->> Modules
+
 local t = require(script.Parent.Parent.t)
+
 local Types = require(script.Parent.Types)
+local Void = require(script.Parent.Void)
+
+-->> World
 
 local World = {}
 
@@ -13,6 +19,14 @@ function World.Spawn(self: _World, ...: Types.Component<any>): number
 	for _, component in components do
 		if not self._storage[component.name] then
 			self._storage[component.name] = {}
+		end
+
+		if self._nextId > #self._storage[component.name] + 1 then
+			for index = 1, self._nextId - 1 do
+				if self._storage[component.name][index] == nil then
+					self._storage[component.name][index] =  Void
+				end
+			end
 		end
 
 		self._storage[component.name][self._nextId] = component.data
@@ -53,12 +67,15 @@ function World.Get(self: _World, id: number, ...: Types.Assembler<any>?): ...any
 				error("Get() -> Argument #"..1 + index.." expected assembler, got "..typeof(assembler), 2)
 			end
 
-			table.insert(componentsToReturn :: {any}, self._storage[tostring(assembler)][id])
+			local data = self._storage[tostring(assembler)][id];
+			(componentsToReturn :: {any})[index] = if data == Void then nil else data
 		end
+
 		return table.unpack(componentsToReturn :: {any})
 	else
 		for component in self._storage do
-			(componentsToReturn :: Types.Dictionary<any>)[component] = self._storage[component][id]
+			local data = self._storage[component][id];
+			(componentsToReturn :: Types.Dictionary<any>)[component] = if data == Void then nil else data
 		end
 		return componentsToReturn :: Types.Dictionary<any>
 	end

--- a/src/init.lua
+++ b/src/init.lua
@@ -2,6 +2,9 @@
 
 return {
     Types = require(script.Types),
+
+    None = require(script.None),
+
     World = require(script.World),
     Assembler = require(script.Assembler),
 }

--- a/src/init.lua
+++ b/src/init.lua
@@ -2,8 +2,8 @@
 
 return {
     Types = require(script.Types),
-
     None = require(script.None),
+    Void = require(script.Void),
 
     World = require(script.World),
     Assembler = require(script.Assembler),


### PR DESCRIPTION
Inserting `nil` values and missing indexes in arrays is problematic. They generate holes in the storage and can lead to data loss (e.g.: In an array A, if there's a gap between 1 and 3, removing 1 also removes 3).

To fix this, "nil" values are represented with symbols which avoid creating holes in the arrays while still being understandable internally by the code.

* **Intended `nil` values get replaced with `None`**
* **Voids get replaced with `Void`.** If you have entity 1 and 3 with a component but 2 doesn't have it, that position becomes void which may lead to data loss. `Void` simply prevents having an actual void.
* **Get returns `nil` on `Void`.** Actual `nil` values get returned as `None`.

Resolves #9