### PR TITLE
Change: Behavior of Remove() for Despawn()

### DIFF
--- a/src/Types.lua
+++ b/src/Types.lua
@@ -22,6 +22,10 @@ Types.Components = t.tuple(Types.Component)
 
 export type Assembler<T> = (data: T) -> Component<T>
 
+function Types.Assembler(assembler: any): boolean
+	if getmetatable(assembler :: any) and getmetatable(assembler :: any)._isAssembler then return true else return false end
+end
+
 -->> Storage
 
 export type Storage = {
@@ -29,7 +33,5 @@ export type Storage = {
 		[number]: any --> Data per Id
 	}
 }
-
-Types.Storage = t.interface({ [t.string] = t.array(t.any) })
 
 return Types


### PR DESCRIPTION
At the current time of writing this, components could be set to `None` _(`nil`)_ and entities could be despawned but components could not be fully removed from an entity. `Remove()` has been renamed as `Despawn()` in favor of a new method called `Remove()` that just removes components from entities, making them appear as `nil` instead of `None` and unable to be queried.

The merge also comes with nice changes in how assertion is handled for assemblers: with a new assert function that makes code blocks smaller. An unnecessary type has been removed and little changes in the behavior of component tuples assertion have been done, displaying more clearly the wrong argument of the tuple when throwing an error.