### PR TITLE
Add Update method and rename old ones

### DIFF
--- a/src/Types.lua
+++ b/src/Types.lua
@@ -18,7 +18,10 @@ export type Component<T> = {
 }
 
 Types.Component = t.interface({data = t.any, name = t.string})
+Types.TableComponent = t.interface({data = t.table, name = t.string})
+
 Types.Components = t.tuple(Types.Component)
+Types.TableComponents = t.tuple(Types.TableComponent)
 
 export type Assembler<T> = (data: T) -> Component<T>
 

--- a/src/World.lua
+++ b/src/World.lua
@@ -182,7 +182,7 @@ function World.OnChange(self: _World, idOrAssembler: number | Types.Assembler<an
 
 	local index: number | string
 
-	if typeof(idOrAssembler) == "table" and not Types.Assembler(idOrAssembler) then
+	if type(idOrAssembler) == "table" and not Types.Assembler(idOrAssembler) then
 		error("OnChange() -> Argument #1 expected assembler, got "..typeof(index), 2)
 	else
 		index = tostring(idOrAssembler)
@@ -246,12 +246,14 @@ function World.Despawn(self: _World, id: number): true
 	if not t.number(id) then error("Despawn() -> Argument #1 expected number, got "..typeof(id), 2) end
 
 	for component in self._storage do
-		self:_NotifyOfChange(component, id, self._storage[component][id], nil)
+		local oldValue = self._storage[component][id]
 		self._storage[component][id] = nil
 
 		if #self._storage[component] == 0 then
 			self._storage[component] = nil
 		end
+
+		self:_NotifyOfChange(component, id, oldValue, nil)
 	end
 
 	self._size -= 1
@@ -315,8 +317,10 @@ function World.Set(self: _World, id: number, ...: Types.Component<any>)
 			self._storage[component.name] = {}
 		end
 
-		self:_NotifyOfChange(component.name, id, self._storage[component.name][id], component.data)
+		local oldValue = self._storage[component.name][id]
 		self._storage[component.name][id] = component.data
+
+		self:_NotifyOfChange(component.name, id, oldValue, self._storage[component.name][id])
 	end
 end
 

--- a/src/World.lua
+++ b/src/World.lua
@@ -131,7 +131,9 @@ export type World = {
 	Spawn: (self: World, ...Types.Component<any>) -> number,
 	Despawn: (self: World, id: number) -> true,
 	Get: (self: World, id: number, ...Types.Assembler<any>?) -> (...any | Types.Dictionary<any>),
-	Set: (self: World, id: number, ...Types.Component<any>) -> true
+	Set: (self: World, id: number, ...Types.Component<any>) -> (),
+	Update: (self: World, id: number, ...Types.Component<{[any]: any}>) -> (),
+	Remove: (self: World, id: number, ...Types.Assembler<any>) -> (),
 }
 
 type _WorldProperties = {
@@ -152,7 +154,7 @@ export type _World = _WorldProperties & {
 	Spawn: (self: _World, ...Types.Component<any>) -> number,
 	Despawn: (self: _World, id: number) -> true,
 	Get: (self: _World, id: number, ...Types.Assembler<any>?) -> (...any | Types.Dictionary<any>),
-	Set: (self: _World, id: number, ...Types.Component<any>) -> true
+	Set: (self: _World, id: number, ...Types.Component<any>) -> true,
 }
 
 local World = {}
@@ -350,7 +352,7 @@ function World.Update(self: _World, id: number, ...: Types.Component<{[any]: any
 	end
 end
 
-function World.Remove(self: _World, id: number, ...: Types.Assembler<any>): true
+function World.Remove(self: _World, id: number, ...: Types.Assembler<any>)
 	if not t.number(id) then error("Remove() -> Argument #1 expected number, got "..typeof(id), 2) end
 
 	local assemblers: {Types.Assembler<any>} = {...}
@@ -362,8 +364,6 @@ function World.Remove(self: _World, id: number, ...: Types.Assembler<any>): true
 		self:_NotifyOfChange(tostring(assembler), id, self._storage[tostring(assembler)][id], nil)
 		self._storage[tostring(assembler)][id] = nil
 	end
-
-	return true
 end
 
 local function Constructor(): World


### PR DESCRIPTION
`Update()` is a similar method to `Set()` which updates the value of a component, specifically a table component, without affecting its other keys. In case that the component is not a table, data is set as it would normally do with `Set()`. This is useful for modifying just the data you're working with from components.

To avoid confusion, previous methods related to the observation of changes may be renamed from:
* `_Update()` to **`_NotifyOfChange()`**
* `OnUpdate()` to **`OnChange()`**

_These names are still to be changed..._

---

The PR also contains fixes for bugs, missing types and improvements in the consistency of action orders (if change listeners are fired after or before actually changing the value).